### PR TITLE
Add top-padding in ingredients page so we can see the header

### DIFF
--- a/app/assets/stylesheets/user_ingredients/_index.scss
+++ b/app/assets/stylesheets/user_ingredients/_index.scss
@@ -6,7 +6,7 @@ $white: #FFFAFB;
   color: $white;
   width: 100%;
   height: auto;
-  padding: 2rem 1rem;
+  padding: 6rem 1rem 2rem 1rem;
   text-align: center;
 
   h1 {


### PR DESCRIPTION
This ensures that our ingredients content doesn't hide behind the navbar (even after when navbar is fixed!)
<img width="465" alt="Screen Shot 2022-11-30 at 12 39 50 PM" src="https://user-images.githubusercontent.com/61673071/204869193-a2599895-1d70-42b3-aca3-b438b52f6d88.png">
