### PR TITLE
Fix login dropdown link color

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -13,7 +13,7 @@
               <% if user_signed_in? %>
                 <%= link_to "Log Out", destroy_user_session_path, class: 'dropdown-item', data: {turbo_method: :delete} %>
               <% else %>
-                <%= link_to "Login", new_user_session_path, class: "nav-link" %>
+                <%= link_to "Login", new_user_session_path, class: "dropdown-item" %>
               <% end %>
             </div>
           </li>


### PR DESCRIPTION
Add `dropdown-link` class to "Login" link

<img width="209" alt="Screen Shot 2022-12-01 at 10 41 58 AM" src="https://user-images.githubusercontent.com/61673071/205095854-22bf4ef5-1cd8-40d4-87d6-7ab74c2da30d.png">
